### PR TITLE
Dependabot: Increase max number of PRs opened

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  open-pull-requests-limit: 20


### PR DESCRIPTION
More work on #11 

Using 20 as the max number of PRs that will be open at a time.
Gatsby get many updates in a week