### PR TITLE
Disabling dependabot for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 20
+  open-pull-requests-limit: 0


### PR DESCRIPTION
* Either go back to yarn v1 or wait for yarn v2 support in dependabot